### PR TITLE
Not working with in-cluster config

### DIFF
--- a/kube-crd.go
+++ b/kube-crd.go
@@ -33,7 +33,7 @@ import (
 
 // return rest config, if path not specified assume in cluster config
 func GetClientConfig(kubeconfig string) (*rest.Config, error) {
-	if kubeconfig != "" {
+	if kubeconfig == "" {
 		return clientcmd.BuildConfigFromFlags("", kubeconfig)
 	}
 	return rest.InClusterConfig()
@@ -41,7 +41,7 @@ func GetClientConfig(kubeconfig string) (*rest.Config, error) {
 
 func main() {
 
-	kubeconf := flag.String("kubeconf", "admin.conf", "Path to a kube config. Only required if out-of-cluster.")
+	kubeconf := flag.String("kubeconf", "", "Path to a kube config. Only required if out-of-cluster.")
 	flag.Parse()
 
 	config, err := GetClientConfig(*kubeconf)


### PR DESCRIPTION
When starting this in-cluster with `./bin` you'll get a panic `panic: stat admin.conf: no such file or directory` -- you'll need `./bin -kubeconfig ""` to work.

I removed the default fallback value so that starting in cluster works out of the box. I think it's generally better to omit the fallback value as  I'm not sure lots of people would store their confi in admin.conf (am I missing something here? never heard of admin.conf before but correct me if I'm wrong).

Up to you, I was just trying this out (BTW amazing tutorial) and thought this could be helpful to others.

Cheers!